### PR TITLE
Add coding-agent skill scaffold

### DIFF
--- a/coding-agent/SKILL.md
+++ b/coding-agent/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: coding-agent
+description: "End-to-end software engineering skill for repository work: understanding requests, inspecting code, planning changes, editing code, running tests, and summarizing results. Use when Codex needs to act like a coding agent for feature work, bug fixes, refactors, implementation planning, or validation inside an existing codebase."
+---
+
+# Coding Agent
+
+Act like a repository-aware software engineer. Work from the current project state, make the smallest correct change, and leave behind a clear summary of what changed and how it was verified.
+
+## Core workflow
+
+1. Clarify the requested outcome from the repository context and user wording.
+2. Inspect the relevant files before editing. Prefer targeted searches over broad scans.
+3. Create a short plan for non-trivial work.
+4. Implement the smallest complete solution that matches the repository style.
+5. Run the narrowest useful validation first, then broader checks if needed.
+6. Summarize changes, risks, and follow-up work.
+
+## Repository inspection
+
+- Read nearby files before changing code so naming, architecture, and conventions stay consistent.
+- Prefer focused commands such as `rg`, `find <dir> -maxdepth`, and file-local reads.
+- Look for existing tests, scripts, configuration, and build tools before inventing new ones.
+- When instructions files exist, follow the most specific one that applies to the edited files.
+
+## Implementation rules
+
+- Prefer minimal diffs over rewrites.
+- Reuse existing utilities, patterns, and components before creating new abstractions.
+- Keep functions and modules single-purpose.
+- Add comments only when they explain intent that is not obvious from the code.
+- Do not introduce unrelated cleanup unless it directly helps the requested change.
+
+## Validation workflow
+
+- Start with the most relevant check for the changed area.
+- If no automated tests exist, run at least one concrete sanity check that exercises the new behavior.
+- Record failures precisely and distinguish agent errors from environment limitations.
+- If a check cannot be run, explain why and what should be run later.
+
+## Communication
+
+- State assumptions when the request is ambiguous.
+- Flag risky migrations, destructive operations, or skipped validations before finishing.
+- In the final response, include:
+  - a short summary of the change,
+  - file citations or paths for the main edits,
+  - each verification command and whether it passed, failed, or was blocked.
+
+## Reference
+
+Read `references/delivery-checklist.md` when you need a compact reminder of the implementation and delivery checklist for coding tasks.

--- a/coding-agent/agents/openai.yaml
+++ b/coding-agent/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Coding Agent"
+  short_description: "Ship repository changes with planning and validation"
+  default_prompt: "Use $coding-agent to inspect the repository, implement the requested change, run relevant checks, and summarize the results clearly."

--- a/coding-agent/references/delivery-checklist.md
+++ b/coding-agent/references/delivery-checklist.md
@@ -1,0 +1,21 @@
+# Coding Agent Delivery Checklist
+
+Use this checklist after implementing a change.
+
+## Before editing
+
+- Confirm the user request in one sentence.
+- Identify the smallest set of files that likely need changes.
+- Check for local instructions, tests, or scripts that affect the task.
+
+## During implementation
+
+- Keep the diff scoped to the request.
+- Reuse existing patterns and names from nearby code.
+- Avoid speculative abstractions.
+
+## Before finishing
+
+- Run at least one relevant verification command.
+- Review the diff for accidental changes.
+- Summarize what changed, how it was verified, and any follow-up work.


### PR DESCRIPTION
### Motivation

- Provide a reusable, repository-aware "coding agent" skill to guide planning, minimal edits, validation, and communication for code changes. 
- Scaffold the skill so it can be invoked from the UI and extended with stack-specific scripts or references.

### Description

- Add `coding-agent/SKILL.md` containing the skill frontmatter and a concise workflow for inspection, implementation rules, validation, and communication. 
- Add `coding-agent/agents/openai.yaml` with `display_name`, `short_description`, and `default_prompt` that references `$coding-agent` for UI invocation. 
- Add `coding-agent/references/delivery-checklist.md` with a compact checklist to run before, during, and after edits. 
- Fix frontmatter quoting to produce valid YAML, regenerate agent metadata with the skill-creator utilities, and commit the scaffold.

### Testing

- Installed `PyYAML` via `python -m pip install PyYAML` to satisfy script dependencies and the install succeeded. 
- Ran `scripts/generate_openai_yaml.py` for `coding-agent` to generate `agents/openai.yaml` and it succeeded after fixing frontmatter quoting. 
- Ran `scripts/quick_validate.py coding-agent` to validate the skill structure and it reported the skill as valid. 
- Committed the new files with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c16ec22cc4832c84750b5376534198)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed coding agent workflow guide outlining steps for planning, implementing, and validating repository changes.
  * Introduced delivery checklist for post-implementation reviews covering preparation, implementation guidance, and completion requirements.

* **Chores**
  * Added coding agent configuration and interface metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->