### PR TITLE
Add GPT growth plan & earning system guide and link from README

### DIFF
--- a/GPT_PLAN_AND_EARNING_SYSTEM.md
+++ b/GPT_PLAN_AND_EARNING_SYSTEM.md
@@ -1,0 +1,256 @@
+# GPT Growth Plan & Earning System
+
+This document gives you a practical roadmap to launch a GPT-powered business and start earning consistently.
+
+## 1) Offer Definition (What you sell)
+Choose one of these business models first:
+
+1. **Service Model (fastest to revenue)**
+   - You use GPT to deliver services (content writing, social media scripts, support automation, lead qualification, etc.).
+2. **Product Model (scalable)**
+   - You package prompts, templates, automations, or a niche assistant and sell subscriptions.
+3. **Hybrid Model (recommended)**
+   - Start with services for cash flow, then convert repeat tasks into a product.
+
+---
+
+## 2) Niche Selection Framework
+Pick a niche where all 3 are true:
+- High pain (urgent problem)
+- Repeat demand (monthly work)
+- Clear ROI (client can measure value)
+
+Good examples:
+- Real estate lead follow-up
+- E-commerce customer support
+- Coaches/consultants content engine
+- Local business appointment booking assistants
+
+---
+
+## 3) 30-Day GPT Launch Plan
+
+### Week 1: Foundation
+- Define one offer and one niche.
+- Build your delivery stack:
+  - GPT (prompt system)
+  - Docs/Notion for SOPs
+  - CRM (HubSpot/Sheets)
+  - Automation (Zapier/Make)
+- Create 3 sample outputs as portfolio proof.
+
+### Week 2: Acquisition
+- Build a one-page offer doc:
+  - Problem
+  - Solution
+  - Timeline
+  - Price
+- Do daily outreach (20–50 targeted contacts/day).
+- Post 1 daily value post showing before/after GPT results.
+
+### Week 3: Delivery + Testimonials
+- Onboard first clients fast (pilot pricing).
+- Track baseline metrics before starting.
+- Deliver weekly reports with measurable improvements.
+- Ask for testimonials + referrals.
+
+### Week 4: Scale
+- Standardize onboarding and fulfillment.
+- Raise price for new clients.
+- Convert common requests into productized packages.
+- Add a monthly retainer option.
+
+---
+
+## 4) Earning System (Money Engine)
+
+## Revenue Ladder
+1. **Entry Offer ($99–$300)**
+   - Audit, strategy call, or mini automation setup.
+2. **Core Offer ($500–$2,000)**
+   - Monthly done-for-you GPT workflows.
+3. **Retainer Offer ($1,500–$5,000+/mo)**
+   - Ongoing optimization, reporting, and automation support.
+4. **Scalable Product ($19–$299/mo)**
+   - Templates, prompt library, or niche AI assistant subscription.
+
+## KPI Targets
+- Outreach sent/day
+- Response rate
+- Sales calls booked/week
+- Close rate
+- Average client value
+- Monthly recurring revenue (MRR)
+
+## Weekly Scoreboard (simple)
+- Leads contacted
+- Calls booked
+- Deals closed
+- Cash collected
+- Churn (if subscription)
+
+---
+
+## 5) Pricing Blueprint
+
+Use value-based pricing:
+- If your GPT workflow saves 20 hours/month, price based on value, not effort.
+- If it increases leads or conversions, tie pricing to business outcome.
+
+Starter pricing guide:
+- Pilot: 50–70% of target price
+- Standard: full price with clear deliverables
+- Premium: faster SLA + deeper analytics + custom workflows
+
+---
+
+## 6) Tool Stack (Lean)
+- **Model/assistant:** ChatGPT or Gemini
+- **Automation:** Zapier or Make
+- **CRM:** HubSpot free / Airtable / Google Sheets
+- **Scheduling:** Calendly
+- **Payments:** Stripe, Google Pay, PhonePe, Paytm
+- **Knowledge base:** Notion
+
+Keep tooling minimal until you reach steady revenue.
+
+---
+
+## 7) Google AI Studio Quick Start
+
+If you want to run this through **Google AI Studio**:
+1. Open: https://aistudio.google.com/
+2. Sign in with your Google account.
+3. Create a new prompt project for your niche workflow.
+4. Save reusable system instructions for your offer.
+5. Test with real client-style inputs.
+6. Export prompt logic into your SOP docs.
+
+> Note: AI Studio availability/features can vary by region and account type.
+
+---
+
+
+## 7.1 Payment Method Setup (India-friendly)
+- Enable **Google Pay**, **PhonePe**, and **Paytm** in your payment gateway/account.
+- Use UPI QR and payment links for faster collection on calls and chats.
+- Add payment instructions in your onboarding doc and invoices.
+- Track paid/unpaid status in your CRM every day.
+
+
+## 7.2 Personal Gateway Setup (Payment + AI)
+
+### Personal payment gateways
+Set these as your default collection methods:
+- **Google Pay** (UPI ID + QR)
+- **PhonePe** (UPI ID + QR)
+- **Paytm** (UPI ID + QR)
+
+Checklist:
+1. Create a dedicated business UPI ID.
+2. Generate and save branded QR codes for all three apps.
+3. Add payment links/QR to proposals, invoices, and WhatsApp templates.
+4. Reconcile payments daily in a simple ledger (date, client, amount, method, status).
+
+### Personal AI gateways
+Use a multi-provider setup so your service stays online if one provider has issues:
+- **Primary AI gateway:** OpenAI API
+- **Secondary AI gateway:** Google Gemini (AI Studio/API)
+- **Optional backup:** Anthropic API
+
+Checklist:
+1. Store API keys in a secure secrets manager (never in plain text docs).
+2. Define fallback routing rules (primary -> secondary -> backup).
+3. Set per-client token/cost limits.
+4. Log latency, error rate, and cost per request weekly.
+
+## 8) Daily Operating Routine (60–90 min)
+- 20 min: prospecting/outreach
+- 15 min: follow-ups
+- 20 min: fulfillment improvements
+- 15 min: publish one proof/content post
+- 10 min: update KPI scoreboard
+
+Consistency beats complexity.
+
+---
+
+## 9) Risk Controls
+- Never share client data in prompts without permission.
+- Use anonymized examples.
+- Keep human approval for sensitive outputs.
+- Document quality checks before delivery.
+
+---
+
+## 10) 90-Day Milestones
+- **Day 30:** First 1–3 paying clients
+- **Day 60:** Repeatable delivery process + referrals
+- **Day 90:** Stable monthly revenue and at least one productized offer
+
+
+---
+
+## 11) Team Earning System
+
+Build a simple compensation model that rewards delivery quality and revenue growth.
+
+### Team roles
+- **Closer/Sales**: closes new clients
+- **Delivery Manager**: owns client outcomes and timelines
+- **Automation/AI Specialist**: builds prompts, workflows, integrations
+- **Content/Support Ops**: posting, follow-up, client communication
+
+### Earning split model (example)
+- **Base pay** for stability (monthly fixed amount)
+- **Performance bonus** tied to KPI score
+- **Revenue share** on paid invoices collected
+
+Suggested starting split of net service margin:
+- 50% business reserve/profit
+- 20% delivery team pool
+- 15% sales/closer pool
+- 10% operations/support pool
+- 5% quality bonus pool
+
+### KPI-linked bonuses
+Assign monthly points and pay bonuses based on score brackets:
+- Client retention
+- On-time delivery
+- Error/rework rate
+- Upsell/referral contribution
+- CSAT/NPS
+
+---
+
+## 12) Team + Earnings Dashboard (Manager View)
+
+Use one dashboard (Airtable/Notion/Sheets/Looker Studio) with these tabs:
+
+### A) Revenue dashboard
+- MRR
+- Cash collected (weekly/monthly)
+- Outstanding invoices
+- Average revenue per client
+- Churn and expansion revenue
+
+### B) Team performance dashboard
+- Tasks completed per member
+- SLA/on-time rate
+- QA score
+- Client satisfaction score
+- Utilization (%)
+
+### C) Payout dashboard
+- Base pay due
+- Bonus earned
+- Revenue share earned
+- Total payout by teammate
+- Payment status (paid/pending)
+
+### Weekly manager routine
+1. Monday: set team targets and deal targets.
+2. Wednesday: review blockers and client health.
+3. Friday: finalize KPI scores and payouts.
+4. Month-end: publish performance report + payout summary.
+

--- a/GPT_PLAN_AND_EARNING_SYSTEM.md
+++ b/GPT_PLAN_AND_EARNING_SYSTEM.md
@@ -142,12 +142,13 @@ If you want to run this through **Google AI Studio**:
 
 ### Personal payment gateways
 Set these as your default collection methods:
-- **Google Pay** (UPI ID + QR)
-- **PhonePe** (UPI ID + QR)
-- **Paytm** (UPI ID + QR)
+- **Primary UPI ID for earnings:** `fino.7307973257@finobank`
+- **Google Pay:** connect this UPI ID and generate/share a QR code
+- **PhonePe:** connect this UPI ID and generate/share a QR code
+- **Paytm:** connect this UPI ID and generate/share a QR code
 
 Checklist:
-1. Create a dedicated business UPI ID.
+1. Use `fino.7307973257@finobank` as the dedicated business UPI ID for earnings.
 2. Generate and save branded QR codes for all three apps.
 3. Add payment links/QR to proposals, invoices, and WhatsApp templates.
 4. Reconcile payments daily in a simple ledger (date, client, amount, method, status).
@@ -231,6 +232,7 @@ Use one dashboard (Airtable/Notion/Sheets/Looker Studio) with these tabs:
 - MRR
 - Cash collected (weekly/monthly)
 - Outstanding invoices
+- UPI collections received at `fino.7307973257@finobank`
 - Average revenue per client
 - Churn and expansion revenue
 

--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ If you want, the next iteration can turn this README into:
 - a product requirements document,
 - a landing page,
 - or a starter app for multi-platform live streaming.
+
+
+## Business planning doc
+- See `GPT_PLAN_AND_EARNING_SYSTEM.md` for a ready-to-use GPT launch plan and earning system.
+
+- Includes team earning system + manager dashboard sections for operations scaling.


### PR DESCRIPTION
### Motivation
- Provide a practical, ready-to-use roadmap for launching a GPT-powered business including offer definition, go-to-market steps, and revenue models.
- Capture operational guidance for payments, multi-provider AI gateways, and a team-based earning system to help scale delivery.
- Surface the guide from the project README so contributors and users can access business guidance alongside the codebase.

### Description
- Added `GPT_PLAN_AND_EARNING_SYSTEM.md`, a comprehensive document covering offer models, niche selection, a 30-day launch plan, revenue ladder and KPI targets, pricing blueprint, tool stack, payment setup, daily routine, risk controls, 90-day milestones, team earning model, and manager dashboards.
- Included India-friendly payment setup and multi-provider AI gateway recommendations with checklists and operational controls.
- Updated `README.md` to reference the new `GPT_PLAN_AND_EARNING_SYSTEM.md` so the business planning doc is discoverable from the project root.

### Testing
- No automated tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb63a65ebc832ca17576d5594ad0d7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive business planning and operations documentation covering launch roadmap, revenue framework, pricing strategy, team earning systems, and manager dashboard for operational scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->